### PR TITLE
Factory for creating WebSocket connection (can be replaced)

### DIFF
--- a/autobahn/autobahn.js
+++ b/autobahn/autobahn.js
@@ -319,6 +319,18 @@ ab.CONNECTION_LOST_SCHEDULED_RECONNECT = 6;
 ab._Deferred = when.defer;
 //ab._Deferred = jQuery.Deferred;
 
+ab._construct = function (url, protocols) {
+   if ("WebSocket" in window) {
+      // Chrome, MSIE, newer Firefox
+      return new WebSocket(url, protocols);
+   } else if ("MozWebSocket" in window) {
+      // older versions of Firefox prefix the WebSocket object
+      return new MozWebSocket(url, protocols);
+   } else {
+      return null;
+   }
+};
+
 ab.Session = function (wsuri, onopen, onclose, options) {
 
    var self = this;
@@ -342,13 +354,8 @@ ab.Session = function (wsuri, onopen, onclose, options) {
    self._txcnt = 0;
    self._rxcnt = 0;
 
-   if ("WebSocket" in window) {
-      // Chrome, MSIE, newer Firefox
-      self._websocket = new WebSocket(self._wsuri, [ab._subprotocol]);
-   } else if ("MozWebSocket" in window) {
-      // older versions of Firefox prefix the WebSocket object
-      self._websocket = new MozWebSocket(self._wsuri, [ab._subprotocol]);
-   } else {
+   self._websocket = ab._construct(self._wsuri, [ab._subprotocol]);
+   if (!self._websocket) {
       if (onclose !== undefined) {
          onclose(ab.CONNECTION_UNSUPPORTED);
          return;


### PR DESCRIPTION
I was working on running WAMP over SockJS. It's not really possible right now, as subprotocols are missing from SockJS (it's a planned feature). I had to hack in support for them.

On the AutobahnJS side I ran into issues because it tries to create the WebSocket instance itself with no way to change the creation. This PR allows the creation to be customized.

Example:

```
ab._construct = SockJS;
ab.connect('http://localhost:8080/broadcast', function (sess) {
    sess.call('isEven', 1).then(ab.log);
    sess.call('isEven', 2).then(ab.log);
});
```
