### PR TITLE
Allow Asynchronous RPC endpoints.

### DIFF
--- a/package/test/test.js
+++ b/package/test/test.js
@@ -16,6 +16,7 @@
 var connect = require('./test_connect.js');
 var rpc_complex = require('./test_rpc_complex.js');
 var rpc_arguments = require('./test_rpc_arguments.js');
+var rpc_async = require('./test_rpc_async.js');
 var rpc_error = require('./test_rpc_error.js');
 var rpc_options = require('./test_rpc_options.js');
 var rpc_progress = require('./test_rpc_progress.js');
@@ -35,6 +36,7 @@ var pubsub_publisher_disclose_me = require('./test_pubsub_publisher_disclose_me.
 
 exports.testConnect = connect.testConnect;
 exports.testRpcArguments = rpc_arguments.testRpcArguments;
+exports.testRpcAsync = rpc_async.testRpcAsync;
 exports.testRpcComplex = rpc_complex.testRpcComplex;
 exports.testRpcError = rpc_error.testRpcError;
 exports.testRpcOptions = rpc_options.testRpcOptions;

--- a/package/test/test_rpc_async.js
+++ b/package/test/test_rpc_async.js
@@ -1,0 +1,67 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  AutobahnJS - http://autobahn.ws, http://wamp.ws
+//
+//  A JavaScript library for WAMP ("The Web Application Messaging Protocol").
+//
+//  Copyright (C) 2011-2014 Tavendo GmbH, http://tavendo.com
+//
+//  Licensed under the MIT License.
+//  http://www.opensource.org/licenses/mit-license.php
+//
+///////////////////////////////////////////////////////////////////////////////
+
+var autobahn = require('./../index.js');
+var testutil = require('./testutil.js');
+
+
+exports.testRpcAsync = function (testcase) {
+    testcase.expect(1);
+    var test = new testutil.Testlog("test/test_rpc_async.txt");
+    var connection = new autobahn.Connection(testutil.config);
+
+    function stars(args, kwargs) {
+        test.log('stars', args, kwargs);
+        kwargs = kwargs || {};
+        kwargs.nick = kwargs.nick || "somebody";
+        kwargs.stars = kwargs.stars || 0;
+        return kwargs.nick + " starred " + kwargs.stars + "x";
+    }
+
+    connection.onopen = function (session) {
+        test.log('Connected');
+
+        session.register('com.async.call', function(args, kwars, cd, done) {
+            setTimeout(function() {
+                done(null, stars(args, kwars));
+            }, 100);
+        }, {
+            async: true
+        });
+
+        session.register('com.async.callbad', function(args, kwars, cd, done) {
+            setTimeout(function() {
+                done('Bad call!!!');
+            }, 100);
+        }, {
+            async: true
+        });
+
+        session.call('com.async.call', [], {nick: 'Homer', stars: 5}).then(function (res) {
+            test.log(res);
+            session.call('com.async.callbad', [], {stars: 2}).then(function(res) {
+                test.log('This call should not pass.');
+            }, function(err) {
+                test.log(err.args[0]);
+                test.log("All finished.");
+                connection.close();
+                var chk = test.check();
+                testcase.ok(!chk, chk);
+                testcase.done();
+            });
+        }, function(err) {
+            test.log(err);
+        });
+    };
+    connection.open();
+};

--- a/package/test/test_rpc_async.txt
+++ b/package/test/test_rpc_async.txt
@@ -1,0 +1,5 @@
+0 "Connected"
+1 "stars" [] {"nick":"Homer","stars":5}
+2 "Homer starred 5x"
+3 "Bad call!!!"
+4 "All finished."


### PR DESCRIPTION
Currently this library does not allow for asynchronous RPC endpoints, where the endpoint needs to perform something asynchronously before returning the results. Here is an example of what I am referring to...

```
var authenticate = function(username, password, done) {
   // Perform an asynchronous authentication.
};
        
session.register('authenticate', function(args, kwars, cd, done) {
  authenticate(kwars.username, kwars.password, done);
}, {
  async: true  /** Option added to let the library know this is async. **/
});
```

This pull requests adds this ability.