### PR TITLE
Prevent browser error when importing Autobahn via Webpack.

### DIFF
--- a/package/lib/session.js
+++ b/package/lib/session.js
@@ -26,7 +26,7 @@ Date.now = Date.now || function() { return +new Date; };
 
 // WAMP "Advanced Profile" support in AutobahnJS per role
 //
-WAMP_FEATURES = {
+var WAMP_FEATURES = {
    caller: {
       features: {
          caller_identification: true,


### PR DESCRIPTION
Adding the variable declaration that way seems to solve the problem. Otherwise the browser will complain that WAMP_FEATURES is not declared.