### PR TITLE
Fix UNSUBSCRIBE not checking if subscription exists

### DIFF
--- a/package/lib/session.js
+++ b/package/lib/session.js
@@ -346,17 +346,17 @@ var Session = function (socket, defer, onchallenge) {
          var r = self._unsubscribe_reqs[request];
 
          var d = r[0];
-         var subscription = r[1];
+         var subscription_id = r[1];
 
-         if (subscription.id in self._subscriptions) {
-            var subs = self._subscriptions[subscription.id];
+         if (subscription_id in self._subscriptions) {
+            var subs = self._subscriptions[subscription_id];
             // the following should actually be NOP, since UNSUBSCRIBE was
             // only sent when subs got empty
             for (var i = 0; i < subs.length; ++i) {
                subs[i].active = false;
                subs[i].on_unsubscribe.resolve();
             }
-            delete self._subscriptions[subscription];
+            delete self._subscriptions[subscription_id];
          }
 
          d.resolve(true);


### PR DESCRIPTION
In the code the field `r[1]` is assigned to `subscription` and in the next line it is accessed as `subscription.id`. But since r[1] is of type number (the subscription id is stored in the `_unsubscribe_reqs` as second entry of the array as type `number`, **not** the `Subscription` object), the expression `subscription.id` will always evaluate to undefined (it will not throw a runtime exception but just evaluate to undefined). This causes that the actual subscription is never retrieved from the `_subscriptions` Hashmap, as `undefined` is not part of the Hashmap.

I corrected the code to what I think was the intent of the original author, stating explicity that the second field in the _unsubscribe_reqs entry is of type number, thus the variable should be `subscription_id` and treated as number.