### PR TITLE
net sockets are closed with ```end()``` instead of ```close()```

### DIFF
--- a/package/lib/transport/rawsocket.js
+++ b/package/lib/transport/rawsocket.js
@@ -301,7 +301,7 @@ Protocol.prototype.DEFAULT_OPTIONS = {
  */
 Protocol.prototype.close = function () {
    this._status = this.STATUS.CLOSED;
-   this._stream.close();
+   this._stream.end();
 
    return this.STATUS.CLOSED;
 };


### PR DESCRIPTION
this fixes crossbario/autobahn-js#169 for me