### PR TITLE
Fix usage of undeclared variable

### DIFF
--- a/package/lib/transport/rawsocket.js
+++ b/package/lib/transport/rawsocket.js
@@ -594,7 +594,7 @@ Protocol.prototype._handleHeaderPacket = function (int32) {
 
       default:
          this._emitter.emit('error', new ProtocolError(
-            'Invalid frame type: 0x' + status.toString(16))
+            'Invalid frame type: 0x' + type.toString(16))
          );
          return this.close();
    }


### PR DESCRIPTION
The `status`variable is undeclared in this context, I assume it should have been `type`.