### PR TITLE
Implemented pluggable serializers and msgpack serialization

### DIFF
--- a/package/lib/autobahn.js
+++ b/package/lib/autobahn.js
@@ -32,6 +32,7 @@ var log = require('./log.js');
 var session = require('./session.js');
 var connection = require('./connection.js');
 var configure = require('./configure.js');
+var serializer = require('./serializer.js');
 
 var persona = require('./auth/persona.js');
 var cra = require('./auth/cra.js');
@@ -50,6 +51,8 @@ exports.Error = session.Error;
 exports.Subscription = session.Subscription;
 exports.Registration = session.Registration;
 exports.Publication = session.Publication;
+
+exports.serializer = serializer;
 
 exports.auth_persona = persona.auth;
 exports.auth_cra = cra;

--- a/package/lib/connection.js
+++ b/package/lib/connection.js
@@ -177,6 +177,9 @@ Connection.prototype._init_transport_factories = function () {
             // defaulting to options.url if none is provided
             transport_options.url = this._options.url;
         }
+        if (!transport_options.serializers) {
+            transport_options.serializers = this._options.serializers;
+        }
         if (!transport_options.protocols) {
             transport_options.protocols = this._options.protocols;
         }

--- a/package/lib/serializer.js
+++ b/package/lib/serializer.js
@@ -32,19 +32,53 @@ exports.JSONSerializer = JSONSerializer;
 
 try {
    var msgpack = require('msgpack-lite');
+   var write_type = require("msgpack-lite/lib/write-type").type;
+   var write_token = require("msgpack-lite/lib/write-token").token;
+
+   // Save the original number encoder
+   var original_number = write_type.number;
+
+   // monkey patch the number encoder to send all generated
+   // WAMP IDs as integers
+   write_type.number = function (encoder, value) {
+      if (Number.isInteger(value) && value > 2147483648 && value <= 9007199254740991) {
+         return write_token[0xcf](encoder, value);
+      }
+      return original_number(encoder, value);
+   };
 
    function MsgpackSerializer() {
-      // https://github.com/mcollina/msgpack5
       this.SERIALIZER_ID = 'msgpack';
       this.BINARY = true;
+      this.codec = msgpack.createCodec();
    }
 
    MsgpackSerializer.prototype.serialize = function (obj) {
-      return msgpack.encode(obj);
+      return msgpack.encode(obj, {codec: this.codec});
    };
 
    MsgpackSerializer.prototype.unserialize = function (payload) {
-      return msgpack.decode(payload);
+      return msgpack.decode(payload, {codec: this.codec});
+   };
+
+   /**
+    * Register a packer and/or unpacker functions for a given type.
+    *
+    * The msgpack specification allows applications to register up to 128 extension
+    * types.
+    *
+    * @param code numeric extension code (between 0-127)
+    * @param type constructor for the given type (only required when packer is defined)
+    * @param packer a function that takes an object and returns a Buffer
+    * @param unpacker a function that takes a Buffer and returns an instance of the given type
+    */
+   MsgpackSerializer.prototype.registerExtType = function (code, type, packer, unpacker) {
+      if (packer && type) {
+         this.codec.addExtPacker(code, type, packer);
+      }
+      if (unpacker) {
+         this.codec.addExtUnpacker(code, unpacker);
+      }
    };
 
    exports.MsgpackSerializer = MsgpackSerializer;

--- a/package/lib/serializer.js
+++ b/package/lib/serializer.js
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  AutobahnJS - http://autobahn.ws, http://wamp.ws
+//
+//  A JavaScript library for WAMP ("The Web Application Messaging Protocol").
+//
+//  Copyright (C) 2011-2016 Tavendo GmbH, http://tavendo.com
+//
+//  Licensed under the MIT License.
+//  http://www.opensource.org/licenses/mit-license.php
+//
+///////////////////////////////////////////////////////////////////////////////
+
+
+function JSONSerializer(replacer, reviver) {
+   this.replacer = replacer;
+   this.reviver = reviver;
+   this.SERIALIZER_ID = 'json';
+   this.BINARY = false;
+}
+
+JSONSerializer.prototype.serialize = function (obj) {
+   return JSON.stringify(obj, this.replacer);
+};
+
+JSONSerializer.prototype.unserialize = function (payload) {
+   return JSON.parse(payload, this.reviver);
+};
+
+exports.JSONSerializer = JSONSerializer;
+
+
+try {
+   var msgpack = require('msgpack-lite');
+
+   function MsgpackSerializer() {
+      // https://github.com/mcollina/msgpack5
+      this.SERIALIZER_ID = 'msgpack';
+      this.BINARY = true;
+   }
+
+   MsgpackSerializer.prototype.serialize = function (obj) {
+      return msgpack.encode(obj);
+   };
+
+   MsgpackSerializer.prototype.unserialize = function (payload) {
+      return msgpack.decode(payload);
+   };
+
+   exports.MsgpackSerializer = MsgpackSerializer;
+} catch (err) {
+   // msgpack-lite not installed
+}

--- a/package/lib/session.js
+++ b/package/lib/session.js
@@ -69,7 +69,7 @@ var WAMP_FEATURES = {
 // generate a WAMP ID
 //
 function newid () {
-   return Math.floor(Math.random() * 2147483648);
+   return Math.floor(Math.random() * 9007199254740992);
 }
 
 

--- a/package/lib/session.js
+++ b/package/lib/session.js
@@ -69,7 +69,7 @@ var WAMP_FEATURES = {
 // generate a WAMP ID
 //
 function newid () {
-   return Math.floor(Math.random() * 9007199254740992);
+   return Math.floor(Math.random() * 2147483648);
 }
 
 

--- a/package/package.json
+++ b/package/package.json
@@ -4,7 +4,8 @@
   "description": "An implementation of The Web Application Messaging Protocol (WAMP).",
   "main": "index.js",
   "browser": {
-    "lib/transport/rawsocket.js": false
+    "lib/transport/rawsocket.js": false,
+    "msgpack-lite": "msgpack-lite/global"
   },
   "scripts": {
     "test": "nodeunit test/test.js"
@@ -12,7 +13,8 @@
   "dependencies": {
     "crypto-js": ">= 3.1.5",
     "when": ">= 3.7.3",
-    "ws": ">= 0.8.0"
+    "ws": ">= 0.8.0",
+    "msgpack-lite": ">= 0.1.17"
   },
   "devDependencies": {
     "browserify": ">= 11.0.1",

--- a/package/test/test.js
+++ b/package/test/test.js
@@ -14,6 +14,7 @@
 // this works via https://github.com/caolan/nodeunit
 
 var connect = require('./test_connect.js');
+var msgpack_serialization = require('./test_msgpack_serialization.js');
 var rpc_complex = require('./test_rpc_complex.js');
 var rpc_arguments = require('./test_rpc_arguments.js');
 var rpc_error = require('./test_rpc_error.js');
@@ -34,6 +35,7 @@ var pubsub_publisher_disclose_me = require('./test_pubsub_publisher_disclose_me.
 
 
 exports.testConnect = connect.testConnect;
+exports.testMsgpackSerialization = msgpack_serialization.testMsgpackSerialization;
 exports.testRpcArguments = rpc_arguments.testRpcArguments;
 exports.testRpcComplex = rpc_complex.testRpcComplex;
 exports.testRpcError = rpc_error.testRpcError;

--- a/package/test/test_msgpack_serialization.js
+++ b/package/test/test_msgpack_serialization.js
@@ -1,0 +1,88 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  AutobahnJS - http://autobahn.ws, http://wamp.ws
+//
+//  A JavaScript library for WAMP ("The Web Application Messaging Protocol").
+//
+//  Copyright (C) 2011-2014 Tavendo GmbH, http://tavendo.com
+//
+//  Licensed under the MIT License.
+//  http://www.opensource.org/licenses/mit-license.php
+//
+///////////////////////////////////////////////////////////////////////////////
+
+var autobahn = require('./../index.js');
+var testutil = require('./testutil.js');
+
+
+exports.testMsgpackSerialization = function (testcase) {
+
+   testcase.expect(1);
+
+   var test = new testutil.Testlog("test/test_msgpack_serialization.txt");
+
+   var serializer = new autobahn.serializer.MsgpackSerializer();
+
+   var config = {
+      url: testutil.config.url,
+      realm: testutil.config.realm,
+      serializers: [serializer]
+   };
+   var connection = new autobahn.Connection(config);
+
+   connection.onopen = function (session) {
+
+      test.log('Connected');
+
+      function echo(args) {
+         return args[0];
+      }
+
+      var endpoints = {
+         'com.myapp.echo': echo
+      };
+
+      var pl1 = [];
+
+      for (var uri in endpoints) {
+         pl1.push(session.register(uri, endpoints[uri]));
+      }
+
+      autobahn.when.all(pl1).then(
+         function () {
+            test.log("All registered.");
+            test.log("Serializer ID: " + session._socket.serializer.SERIALIZER_ID);
+
+            var pl2 = [];
+
+            var vals1 = [1.7, "hello", [1, 2, -3], {a: 5, b: "hello2"}, null];
+
+            for (var i = 0; i < vals1.length; ++i) {
+
+               pl2.push(session.call('com.myapp.echo', [vals1[i]]).then(
+                  function (res) {
+                     test.log("Result:", res);
+                  },
+                  function (err) {
+                     test.log("Error:", err.error, err.args, err.kwargs);
+                  }
+               ));
+            }
+
+            autobahn.when.all(pl2).then(function () {
+               test.log("All finished.");
+               connection.close();
+
+               var chk = test.check();
+               testcase.ok(!chk, chk);
+               testcase.done();
+            });
+         },
+         function () {
+            test.log("Registration failed!", arguments);
+         }
+      );
+   };
+
+   connection.open();
+};

--- a/package/test/test_msgpack_serialization.js
+++ b/package/test/test_msgpack_serialization.js
@@ -55,7 +55,7 @@ exports.testMsgpackSerialization = function (testcase) {
 
             var pl2 = [];
 
-            var vals1 = [1.7, "hello", [1, 2, -3], {a: 5, b: "hello2"}, null];
+            var vals1 = [1.7, "hello", [1, 2, -3], {a: 5, b: "hello2"}, [-9007199254740991, 9007199254740991], null];
 
             for (var i = 0; i < vals1.length; ++i) {
 

--- a/package/test/test_msgpack_serialization.txt
+++ b/package/test/test_msgpack_serialization.txt
@@ -5,5 +5,6 @@
 4 "Result:" "hello"
 5 "Result:" [1,2,-3]
 6 "Result:" {"a":5,"b":"hello2"}
-7 "Result:" null
-8 "All finished."
+7 "Result:" [-9007199254740991,9007199254740991]
+8 "Result:" null
+9 "All finished."

--- a/package/test/test_msgpack_serialization.txt
+++ b/package/test/test_msgpack_serialization.txt
@@ -1,0 +1,9 @@
+0 "Connected"
+1 "All registered."
+2 "Serializer ID: msgpack"
+3 "Result:" 1.7
+4 "Result:" "hello"
+5 "Result:" [1,2,-3]
+6 "Result:" {"a":5,"b":"hello2"}
+7 "Result:" null
+8 "All finished."

--- a/package/test/testutil.js
+++ b/package/test/testutil.js
@@ -67,7 +67,7 @@ Testlog.prototype.log = function () {
 
    var self = this;
 
-   //console.log.apply(this, arguments);
+   console.log.apply(this, arguments);
    self._log.push(arguments);
 };
 


### PR DESCRIPTION
I had to reduce the range of the randomly generated WAMP IDs because msgpack serializes numbers larger than signed 32-bit numbers as floats (see [this issue](https://github.com/kawanet/msgpack-lite/issues/1) for more information).