### PR TITLE
Fix typo in the docs for connection retry condition

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -133,7 +133,7 @@ autobahn.Connection.onclose = function (reason, details) {
 `reason` is a string with the possible values
 
 -   `"closed"`: The connection was closed explicitly (by the application or server). No automatic reconnection will be tried.
--   `"lost"`: The connection had been formerly established at least once, but now was lost. Automatic reconnection will happen **unless you return falsy** from this callback.
+-   `"lost"`: The connection had been formerly established at least once, but now was lost. Automatic reconnection will happen **unless you return truthy** from this callback.
 -   `"unreachable"`: The connection could not be established in the first place. No automatic reattempt will happen, since most often the cause is fatal (e.g. invalid server URL or server unreachable)
 -   `unsupported`: No WebSocket transport could be created. For security reasons the WebSocket spec states that there should not be any specific errors for network-related issues, so no details are returned in this case either.
 


### PR DESCRIPTION
L370 and L387 of (https://github.com/crossbario/autobahn-js/blob/master/package/lib/connection.js#L387) show that the docs should state `unless truthy is returned`