### PR TITLE
Solution proposal for Issue #220

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 *.log
 *.pyc
 *.pid
+.idea/
+package/.crossbar/

--- a/package/package.json
+++ b/package/package.json
@@ -11,12 +11,14 @@
         "test": "nodeunit test/test.js"
     },
     "dependencies": {
-        "bufferutil": ">= 1.2.1",
         "crypto-js": ">= 3.1.5",
-        "utf-8-validate": ">= 1.2.1",
         "when": ">= 3.7.3",
         "ws": ">= 0.8.0",
         "msgpack-lite": ">= 0.1.17"
+    },
+    "optionalDependencies": {
+        "bufferutil": ">= 1.2.1",
+        "utf-8-validate": ">= 1.2.1"
     },
     "devDependencies": {
         "browserify": ">= 11.0.1",

--- a/package/test/testutil.js
+++ b/package/test/testutil.js
@@ -126,6 +126,9 @@ Testlog.prototype.check = function () {
 
    if (fs.existsSync(self._filename)) {
       var slog_baseline = fs.readFileSync(self._filename);
+      //TH 26.07.2016 on Windows platform replace crlf in baseline file with Unix style lf
+     //if the file is already in unix format nothing will be replaced, so it works also in this case
+      if (process.platform==="win32") slog_baseline=slog_baseline.toString().replace(/\r\n/g,"\n");
       if (slog != slog_baseline) {
          return "\nExpected:\n\n" + slog_baseline + "\n\n\nGot:\n\n" + slog + "\n\n";
       } else {


### PR DESCRIPTION
Hi,
here my approach for issue #220. It seems to be sufficent to move bufferutil and utf-8-validate to the optional dependencies section. 
ws has already wrappers around this modules wich load a fallback written in JavaScript.
E.g. in ws/lib/BufferUtil.js:
```
try {
  module.exports = require('bufferutil');
} catch (e) {
  module.exports = require('./BufferUtil.fallback');
}
```
I have verified with debugging both cases: The fallback is used when the modules are missing, when the modules are existing they are loaded. 

Regarding npm install:
On machine which correclty configured and installed C/C++ toolchain nothing changes, npm install runs as before and will build and install both native modules.

On a machine without C/C++ toolchain (e.g. a "plain" Windows installation) the npm install will also try to build the modules but will complain that it failed.
The difference is now, that npm will not abort the installation, it will continue with emitting the warnings:
```
npm WARN optional dep failed, continuing bufferutil@1.2.1
npm WARN optional dep failed, continuing utf-8-validate@1.2.1
```
As an example you can see a complete log of an npm install session here:
[npm install.txt](https://github.com/crossbario/autobahn-js/files/384327/npm.install.txt)

I have run the test suite with and without the native modules. All was ok.

To run the test under Windows I have added some "workaround" for the line-ending problem.
I have added it to this pull request. Maybe you like it. If not, just ignore it.

Sorry for the .gitignore in the request, please ignore it...

I have not yet tested under Linux,  I will do it later at home, I have no suitable Linux installation in the office :-)





