### PR TITLE
Add withCredentials = true so that cookie is sent in longpoll mode

### DIFF
--- a/package/lib/util.js
+++ b/package/lib/util.js
@@ -58,7 +58,7 @@ var http_post = function (url, data, timeout) {
 
    var d = when.defer();
    var req = new XMLHttpRequest();
-
+   req.withCredentials = true; // pass along cookies
    req.onreadystatechange = function () {
 
       if (req.readyState === 4) {


### PR DESCRIPTION
For session-renegotiation purpose, we need the client send cookie along with the request.

So it works in this way after this fix.

## Step 1 . Client first  sends HTTP OPTIONS request

```
OPTIONS /longpoll/open HTTP/1.1
Host: 127.0.0.1:8080
Connection: keep-alive
Cache-Control: max-age=0
Access-Control-Request-Method: POST
Origin: http://127.0.0.1:8720
User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36
Access-Control-Request-Headers: content-type
Accept: */*
Referer: http://127.0.0.1:8720/cors.html
Accept-Encoding: gzip, deflate, sdch
Accept-Language: en,zh-CN;q=0.8,zh;q=0.6
```

## Step 2. Server response like below.

```
HTTP/1.1 200 OK
content-type: text/javascript
access-control-allow-origin: http://127.0.0.1:8720
access-control-allow-headers: Authorization,Content-Type,Cookie,Origin
access-control-allow-methods: GET,POST,OPTIONS
access-control-allow-credentials: true
```

## Step 3. Then client sends the POST request

```
POST /longpoll/open HTTP/1.1
Host: 127.0.0.1:8080
Connection: keep-alive
Content-Length: 29
Origin: http://127.0.0.1:8720
User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36
Content-type: application/json; charset=UTF-8
Accept: */*
Referer: http://127.0.0.1:8720/cors.html
Accept-Encoding: gzip, deflate
Accept-Language: en,zh-CN;q=0.8,zh;q=0.6
```

## Step 4. Then server response and set the cookie

```
HTTP/1.1 200 OK
content-type: text/javascript
access-control-allow-origin: http://127.0.0.1:8720
access-control-allow-headers: Authorization,Content-Type,Cookie,Origin
access-control-allow-methods: GET,POST,OPTIONS
access-control-allow-credentials: true
connection: keep-alive
content-length: 71
set-cookie: cid=6H-3ePfI8JAQaA5ho2NuRj7kT; Path=/; HTTPOnly

{"protocol": "wamp.2.json", "transport": "6H-3ePfI8JAQaA5ho2NuRj7kT-8"}
```

Without `withCredentials = true`,  the cookie won't be accepted by the client.