### PR TITLE
Add additional check for object prior to property lookup.

### DIFF
--- a/package/lib/session.js
+++ b/package/lib/session.js
@@ -504,7 +504,7 @@ var Session = function (socket, defer, onchallenge) {
          // from one of the subscription handler objects attached to the subscription
          // since for non-pattern subscriptions this is not sent over the wire
          var ed = new Event(publication,
-                            details.topic || subs[0].topic,
+                            details.topic || (subs[0] && subs[0].topic),
                             details.publisher,
                             details.publisher_authid,
                             details.publisher_authrole


### PR DESCRIPTION
Fixes error that is thrown when `subs[0]` doesn't exist in https://github.com/crossbario/autobahn-js/blob/master/package/lib/session.js#L507

from
```
         var ed = new Event(publication,
                            details.topic || subs[0].topic,
                            details.publisher,
                            details.publisher_authid,
                            details.publisher_authrole
```
to
```
         var ed = new Event(publication,
                            details.topic || (subs[0] && subs[0].topic),
                            details.publisher,
                            details.publisher_authid,
                            details.publisher_authrole
```
Reference Issue: https://github.com/crossbario/autobahn-js/issues/183