### PR TITLE
Fix for msgpack serialization support

### DIFF
--- a/package/lib/serializer.js
+++ b/package/lib/serializer.js
@@ -32,20 +32,6 @@ exports.JSONSerializer = JSONSerializer;
 
 try {
    var msgpack = require('msgpack-lite');
-   var write_type = require("msgpack-lite/lib/write-type").type;
-   var write_token = require("msgpack-lite/lib/write-token").token;
-
-   // Save the original number encoder
-   var original_number = write_type.number;
-
-   // monkey patch the number encoder to send all generated
-   // WAMP IDs as integers
-   write_type.number = function (encoder, value) {
-      if (Number.isInteger(value) && value > 2147483648 && value <= 9007199254740991) {
-         return write_token[0xcf](encoder, value);
-      }
-      return original_number(encoder, value);
-   };
 
    function MsgpackSerializer() {
       this.SERIALIZER_ID = 'msgpack';
@@ -58,7 +44,8 @@ try {
    };
 
    MsgpackSerializer.prototype.unserialize = function (payload) {
-      return msgpack.decode(payload, {codec: this.codec});
+      // need to encapsulate ArrayBuffer into Uint8Array for msgpack decoding
+      return msgpack.decode(new Uint8Array(payload), {codec: this.codec});
    };
 
    /**

--- a/package/lib/session.js
+++ b/package/lib/session.js
@@ -20,6 +20,9 @@ var when_fn = require("when/function");
 var log = require('./log.js');
 var util = require('./util.js');
 
+// require('int64-buffer') for correct msgpack serialization of large integers
+var Uint64BE = require('int64-buffer').Uint64BE;
+
 // IE fallback (http://afuchs.tumblr.com/post/23550124774/date-now-in-ie8)
 Date.now = Date.now || function() { return +new Date; };
 
@@ -67,9 +70,10 @@ var WAMP_FEATURES = {
 
 
 // generate a WAMP ID
-//
+// 
 function newid () {
-   return Math.floor(Math.random() * 9007199254740992);
+   // msgpack: Uint64BE ensures that ID is encoded as int instead of double
+   return new Uint64BE(Math.floor(Math.random() * 9007199254740992));
 }
 
 

--- a/package/package.json
+++ b/package/package.json
@@ -14,7 +14,8 @@
         "crypto-js": ">= 3.1.5",
         "when": ">= 3.7.3",
         "ws": ">= 0.8.0",
-        "msgpack-lite": ">= 0.1.17"
+        "msgpack-lite": ">= 0.1.18",
+        "int64-buffer": ">= 0.1.5"
     },
     "optionalDependencies": {
         "bufferutil": ">= 1.2.1",

--- a/package/test/test.js
+++ b/package/test/test.js
@@ -14,7 +14,7 @@
 // this works via https://github.com/caolan/nodeunit
 
 var connect = require('./test_connect.js');
-//var msgpack_serialization = require('./test_msgpack_serialization.js');
+var msgpack_serialization = require('./test_msgpack_serialization.js');
 var rpc_complex = require('./test_rpc_complex.js');
 var rpc_arguments = require('./test_rpc_arguments.js');
 var rpc_error = require('./test_rpc_error.js');
@@ -33,7 +33,7 @@ var pubsub_wildcard_sub = require('./test_pubsub_wildcard_sub.js');
 
 
 exports.testConnect = connect.testConnect;
-//exports.testMsgpackSerialization = msgpack_serialization.testMsgpackSerialization;
+exports.testMsgpackSerialization = msgpack_serialization.testMsgpackSerialization;
 exports.testRpcArguments = rpc_arguments.testRpcArguments;
 exports.testRpcComplex = rpc_complex.testRpcComplex;
 exports.testRpcError = rpc_error.testRpcError;


### PR DESCRIPTION
- removed WAMP ID monkey patch
- use Uint64BE for WAMP ID (depends on int64-buffer)
- fixed bug when decoding ArrayBuffer (see https://github.com/kawanet/msgpack-lite/issues/44)
- (reactivated msgpack tests)

This PR fixes msgpack-lite serialization and removes the previously needed monkey patch.

see:
- https://github.com/crossbario/autobahn-js/issues/236
- https://github.com/crossbario/autobahn-js/issues/197

probably also related to:
- https://github.com/crossbario/autobahn-js/issues/231
- https://github.com/crossbario/autobahn-js/issues/67 (latest entry)

Requires msgpack-lite >= 0.1.18 (currently 0.1.17)
Requires int64-buffer (currently not required)

All tests passed with msgpack-lite@0.1.18 & int64-buffer@0.1.5.

Also tested with real-world example of sending binary data with Autobahn Python using msgpack serialization to web-browser Autobahn JS client.
