### PR TITLE
put google-closure-compiler in devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "crypto-js": ">= 3.1.8",
-    "google-closure-compiler": "^20170218.0.0",
     "int64-buffer": ">= 0.1.9",
     "msgpack-lite": ">= 0.1.26",
     "cbor": ">= 3.0.0",
@@ -25,8 +24,9 @@
   },
   "devDependencies": {
     "browserify": ">= 13.1.1",
-    "nodeunit": ">= 0.10.2",
-    "deep-equal": ">= 1.0.1"
+    "deep-equal": ">= 1.0.1",
+    "google-closure-compiler": "^20170218.0.0",
+    "nodeunit": ">= 0.10.2"
   },
   "browser": {
     "ws": false,


### PR DESCRIPTION
I was trying to run all the environment to run tests, but failed after hour trying.
This is related to wix/kissfs/issues/37