### PR TITLE
websocket.js - pass more options to ws in nodejs

### DIFF
--- a/lib/transport/websocket.js
+++ b/lib/transport/websocket.js
@@ -85,16 +85,21 @@ Factory.prototype.create = function () {
          var WebSocket = require('ws'); // https://github.com/einaros/ws
          var websocket;
 
+         var options = { 
+            agent : self._options.agent,
+            headers : self._options.headers
+         };
+         
          var protocols;
          if (self._options.protocols) {
             protocols = self._options.protocols;
             if (Array.isArray(protocols)) {
                protocols = protocols.join(',');
             }
-            websocket = new WebSocket(self._options.url, {protocol: protocols});
-         } else {
-            websocket = new WebSocket(self._options.url);
-         }
+            options.protocol = protocols;
+         } 
+         
+         websocket = new WebSocket(self._options.url, options);
 
          transport.send = function (msg) {
             var payload = transport.serializer.serialize(msg);


### PR DESCRIPTION
This change pass more options to ws in nodejs to

* add http header in the WebSocket handshake.
* use a proxy to debug the connection

Example usage code
```
new autobahn.Connection({
    transports: [
        {
            'agent' : new HttpsProxyAgent('http://127.0.0.1:8888'), // optional agent allows to use proxy to debug the connection
            'type': 'websocket',
            'url': 'ws://127.0.0.1',
            'max_retries': 3,
            'headers' : {
               'Cookie': 'stag=' + encodeURIComponent(stag) // add cookie in the header
            }
        }
    ]
});
```