### PR TITLE
Issue 224 client errors hide away

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -208,22 +208,39 @@ Options that control **WebSocket subprotocol handling**:
 Options that define **Custom error handlers:**
 -   `on_user_error`: *function* - This error handler is called in the following cases: 
     - an exception raised in `onopen`, `onclose`, `onchallenge` callbacks,
-    - an exception raised in a handler function of subscription or a register methods,
+    - an exception raised in the event handler in the subscriber role,
+    - an error occurred in the invocation handler in the callee role (the handler called in the client, before 
+      the error message is sent back to the Dealer.)
 -   `on_internal_error`: *function* - This error handler is called in the following cases:
     - not able to create a Wamp transport,
     - when a protocol violation is occured,
     - when no `onchallenge` defined, but a challenge request is received due to authenticate the client,
 
-```js
-    
+```javascript
+    var connection = new autobahn.Connection({
+       on_user_error: function (error, customErrorMessage) {
+           // here comes your custom error handling, when a 
+           // something went wrong in a user defined callback.
+        },
+        on_internal_error: function (error, customErrorMessage) {
+           // here comes your custom error handling, when a 
+           // something went wrong in the autobahn core.
+        }
+        // ... other options
+    });
 
 ```
 
+> **note**
+>
+> If no error handler is defined for these functions, an error level consol log will be written. 
 
 > **note**
 >
-> If no error handler is defined for these functions, an error level consol log will be logged. 
->
+> In a case of error handling in the Callee role, when the invocation handler is executed, the error
+> is reported on the Callee side (with the custom error handler or an error log), but despite that the
+> error is sent back to the Dealer, and the Caller will receive a `runtime.error` wamp message.
+  
   
 Connection Properties
 ---------------------

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -205,6 +205,26 @@ Options that control **WebSocket subprotocol handling**:
 -   `skip_subprotocol_check`: Not yet implemented.
 -   `skip_subprotocol_announce`: Not yet implemented.
 
+Options that define **Custom error handlers:**
+-   `on_user_error`: *function* - This error handler is called in the following cases: 
+    - an exception raised in `onopen`, `onclose`, `onchallenge` callbacks,
+    - an exception raised in a handler function of subscription or a register methods,
+-   `on_internal_error`: *function* - This error handler is called in the following cases:
+    - not able to create a Wamp transport,
+    - when a protocol violation is occured,
+    - when no `onchallenge` defined, but a challenge request is received due to authenticate the client,
+
+```js
+    
+
+```
+
+
+> **note**
+>
+> If no error handler is defined for these functions, an error level consol log will be logged. 
+>
+  
 Connection Properties
 ---------------------
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -148,11 +148,10 @@ Connection.prototype._create_transport = function () {
             return transport;
          }
       } catch (e) {
-         // ignore
-         log.warn("could not create WAMP transport '" + transport_factory.type + "': " + e);
+          var error_message = "could not create WAMP transport '" + transport_factory.type + "': ";
+          util.handle_error(self._options.on_internal_error, e, error_message);
       }
    }
-
    log.warn('could not create any WAMP transport');
    return null;
 };
@@ -192,7 +191,7 @@ Connection.prototype._init_transport_factories = function () {
                 this._transport_factories.push(transport_factory);
             }
         } catch (exc) {
-            console.error(exc);
+            util.handle_error(self._options.on_internal_error, exc);
         }
     }
 };
@@ -279,7 +278,7 @@ Connection.prototype.open = function () {
       try {
          self._transport = self._create_transport();
       } catch (e) {
-         console.log(e);
+          util.handle_error(self._options.on_internal_error, e);
       }
 
       if (!self._transport) {
@@ -299,7 +298,7 @@ Connection.prototype.open = function () {
       }
 
       // create a new WAMP session using the WebSocket connection as transport
-      self._session = new session.Session(self._transport, self._defer, self._options.onchallenge);
+      self._session = new session.Session(self._transport, self._defer, self._options.onchallenge, self._options.on_user_error, self._options.on_internal_error);
       self._session_close_reason = null;
       self._session_close_message = null;
 
@@ -322,7 +321,7 @@ Connection.prototype.open = function () {
                details.transport = self._transport.info;
                self.onopen(self._session, details);
             } catch (e) {
-               log.debug("Exception raised from app code while firing Connection.onopen()", e);
+                util.handle_error(self._options.on_user_error, e, "Exception raised from app code while firing Connection.onopen()");
             }
          }
       };
@@ -375,7 +374,7 @@ Connection.prototype.open = function () {
                // Connection.onclose() allows to cancel any subsequent retry attempt
                var stop_retrying = self.onclose(reason, details);
             } catch (e) {
-               log.debug("Exception raised from app code while firing Connection.onclose()", e);
+                util.handle_error(self._options.on_user_error, e, "Exception raised from app code while firing Connection.onclose()");
             }
          }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -768,7 +768,7 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
                }
                self._send_wamp(progress_msg);
             }
-         };
+         }
 
          // we want to provide the regitration procedure to the handler and may
          // need to get this from the registration object attached to the registration
@@ -835,7 +835,7 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
                // send WAMP message
                //
                self._send_wamp(reply);
-               util.handle_error(_self._on_user_error, err);
+               util.handle_error(self._on_user_error, err, "Exception raised in invocation handler:");
             }
          );
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -218,7 +218,7 @@ var MSG_TYPE = {
 
 
 
-var Session = function (socket, defer, onchallenge) {
+var Session = function (socket, defer, onchallenge, on_user_error, on_internal_error) {
 
    var self = this;
 
@@ -230,6 +230,11 @@ var Session = function (socket, defer, onchallenge) {
 
    // the WAMP authentication challenge handler
    self._onchallenge = onchallenge;
+
+   // custom error handlers
+   self._on_user_error = on_user_error;
+   self._on_internal_error = on_internal_error;
+
 
    // the WAMP session ID
    self._id = null;
@@ -276,8 +281,8 @@ var Session = function (socket, defer, onchallenge) {
 
 
    self._protocol_violation = function (reason) {
-      log.warn("failing transport due to protocol violation: " + reason);
       self._socket.close(1002, "protocol violation: " + reason);
+      util.handle_error(self._on_internal_error, Error("failing transport due to protocol violation: " + reason))
    };
 
    self._MESSAGE_MAP = {};
@@ -511,7 +516,7 @@ var Session = function (socket, defer, onchallenge) {
             try {
                sub.handler(args, kwargs, ed, sub);
             } catch (e) {
-               log.debug("Exception raised in event handler", e);
+                util.handle_error(self._on_user_error, e, "Exception raised in event handler:");
             }
          }
 
@@ -830,6 +835,7 @@ var Session = function (socket, defer, onchallenge) {
                // send WAMP message
                //
                self._send_wamp(reply);
+               util.handle_error(_self._on_user_error, err);
             }
          );
 
@@ -927,15 +933,14 @@ var Session = function (socket, defer, onchallenge) {
                      self._send_wamp(msg);
                   },
                   function (err) {
-                     log.debug("onchallenge() raised:", err);
-
-                     var msg = [MSG_TYPE.ABORT, {message: "sorry, I cannot authenticate (onchallenge handler raised an exception)"}, "wamp.error.cannot_authenticate"];
-                     self._send_wamp(msg);
-                     self._socket.close(1000);
+                      util.handle_error(self._on_user_error, err, "onchallenge() raised: ");
+                      var msg = [MSG_TYPE.ABORT, {message: "sorry, I cannot authenticate (onchallenge handler raised an exception)"}, "wamp.error.cannot_authenticate"];
+                      self._send_wamp(msg);
+                      self._socket.close(1000);
                   }
                );
             } else {
-               log.debug("received WAMP challenge, but no onchallenge() handler set");
+               util.handle_error(self._on_internal_error, Error("received WAMP challenge, but no onchallenge() handler set"));
 
                var msg = [MSG_TYPE.ABORT, {message: "sorry, I cannot authenticate (no onchallenge handler set)"}, "wamp.error.cannot_authenticate"];
                self._send_wamp(msg);

--- a/lib/util.js
+++ b/lib/util.js
@@ -264,7 +264,23 @@ var defaults = function () {
    return base;
 };
 
+/**
+ * If an error handler function is given, it is called with the error instance, otherwise log the error to the console
+ * with a possible custom error message prefix. The custom message is passed also the error handler.
+ *
+ * @param {function} handler - The error handler function.
+ * @param {object | Error} error - The error instance.
+ * @param {string} [error_message] - The custom error message, optional.
+ */
+var handle_error = function(handler, error, error_message) {
+    if(typeof handler === 'function') {
+        handler.apply(error, error_message);
+    } else {
+        console.error(error_message || 'Unhandled exception raised: ', error);
+    }
+}
 
+exports.handle_error = handle_error;
 exports.rand_normal = rand_normal;
 exports.assert = assert;
 exports.http_post = http_post;

--- a/lib/util.js
+++ b/lib/util.js
@@ -274,7 +274,7 @@ var defaults = function () {
  */
 var handle_error = function(handler, error, error_message) {
     if(typeof handler === 'function') {
-        handler.apply(error, error_message);
+        handler(error, error_message);
     } else {
         console.error(error_message || 'Unhandled exception raised: ', error);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -70,3 +70,8 @@ exports.testPubsubEligible = pubsub_eligible.testPubsubEligible;
 exports.testPubsubPrefixSub = pubsub_prefix_sub.testPubsubPrefixSub;
 exports.testPubsubWildcardSub = pubsub_wildcard_sub.testPubsubWildcardSub;
 exports.testPubsubMultipleMatchingSubs = pubsub_multiple_matching_subs.testPubsubMultipleMatchingSubs;
+
+exports.errorHandlingOnOpen = require('./test_error_handling').errorHandlingOnOpen;
+exports.errorHandlingOnClose = require('./test_error_handling').errorHandlingOnClose;
+exports.errorHandlingOnEvent = require('./test_error_handling').errorHandlingOnEvent;
+exports.errorHandlingOnInvocation = require('./test_error_handling').errorHandlingOnInvocation;

--- a/test/test_error_handling.js
+++ b/test/test_error_handling.js
@@ -1,0 +1,204 @@
+/**
+ * End to end test cases to test the on_user_error_handler feature, when an error is occurred in a user defined
+ * handlers (onopen, onclose, oninvoke, onevent).
+ */
+
+var autobahn = require('./../index.js');
+var testutil = require('./testutil.js');
+
+// It should call the on_user_error handler, when an exception is thrown in the onopen callback.
+exports.errorHandlingOnOpen = function (testcase) {
+
+    // Prepare the test case
+    testcase.expect(3);
+    var timeout = testutil.create_timeout_handler(testcase);
+    var test = new testutil.Testlog("test/test_error_handling_on_open.txt");
+    var config = Object.assign({}, testutil.config);
+    var expectedErrorMessage = "On open user error.";
+    var expectedCustomMessage = "Exception raised from app code while firing Connection.onopen()";
+
+    // Define the tested feature's on user error handler. The test case ends here.
+    config.on_user_error = function (error, customMessage) {
+
+        test.log("Step 4: The user error handler is called");
+        testcase.deepEqual(error.message, expectedErrorMessage);
+        testcase.deepEqual(customMessage, expectedCustomMessage);
+
+        test.log("Step 5: Finish the test case");
+        var check = test.check();
+        testcase.ok(!check, check);
+        timeout.clear();
+        testcase.done();
+    };
+
+    var connection = new autobahn.Connection(config);
+    connection.onopen = function (session) {
+        test.log("Step 2: The onopen handler is called.");
+        test.log("Step 3: A user error is occurred in the handler.");
+        throw Error(expectedErrorMessage);
+    };
+
+    connection.onclose = function(reason) {
+        testcase.ok(false, "Error: Connection closed, it shouldn\'t be opened. Close reason:", reason);
+    };
+
+    // Execute the test case
+    test.log("Step 1: open a connection.");
+    timeout.set();
+    connection.open();
+};
+
+// It should call the on_user_error handler, when an exception is thrown in the onclose callback.
+exports.errorHandlingOnClose = function (testcase) {
+
+    // Prepare the test case
+
+    testcase.expect(3);
+    var timeout = testutil.create_timeout_handler(testcase);
+    var test = new testutil.Testlog("test/test_error_handling_on_colse.txt");
+    var config = Object.assign({}, testutil.config);
+    var expectedErrorMessage = "On close user error.";
+    var expectedCustomMessage = "Exception raised from app code while firing Connection.onclose()";
+
+    // Define the tested feature's on user error handler. The test case ends here.
+    config.on_user_error = function (error, customMessage) {
+        test.log("Step 6: The error handler is called.")
+        testcase.deepEqual(error.message, expectedErrorMessage);
+        testcase.deepEqual(customMessage, expectedCustomMessage);
+
+        test.log("Step 7: finishing the test case.")
+        var check = test.check();
+        testcase.ok(!check, check);
+        timeout.clear();
+        testcase.done();
+    };
+
+    var connection = new autobahn.Connection(config);
+
+    connection.onopen = function (session) {
+        test.log("Step 2: the onopen handler is called.")
+        test.log("Step 3: close the connection.")
+        connection.close();
+    };
+
+    connection.onclose = function(reason) {
+        test.log("Step 4: the onclose handler is called")
+        test.log("Step 5: the handler has a user error")
+        throw Error(expectedErrorMessage);
+    };
+
+    // Execute the test case:
+
+    test.log("Step 1: open a connection")
+    timeout.set();
+    connection.open();
+};
+
+// It should call the on_user_error handler in the Subscriber, when an exception is thrown in the event handler in a case of a subscription.
+exports.errorHandlingOnEvent = function(testcase) {
+
+    // Prepare the test case
+
+    testcase.expect(3);
+    var timeout = testutil.create_timeout_handler(testcase);
+    var test = new testutil.Testlog("test/test_error_handling_on_event.txt");
+    var config = Object.assign({}, testutil.config);
+    var expectedErrorMessage = "Event handler user error.";
+    var expectedCustomMessage = "Exception raised in event handler:";
+
+    // Define the tested feature's on user error handler. The test case ends here.
+    config.on_user_error = function (error, customMessage) {
+
+        test.log("Step 6: the on user error is called")
+        testcase.deepEqual(error.message, expectedErrorMessage);
+        testcase.deepEqual(customMessage, expectedCustomMessage);
+
+        test.log("Step 7: finishing the test cases");
+        var check = test.check();
+        testcase.ok(!check, check);
+        timeout.clear();
+        testcase.done();
+    };
+
+    // Execute the test case
+
+    test.log("Step 1: make two connections")
+    timeout.set();
+    autobahn.when.all(testutil.connect_n(2, config)).then(function(sessions) {
+        var subscriber = sessions[0];
+        var publisher = sessions[1];
+
+        test.log("Step 2: subscribe to a topic")
+        subscriber.subscribe("com.myapp.topic", function() {
+            test.log("Step 4: the event handler is called");
+
+            test.log("Step 5: an error thrown in the event handler");
+            throw Error(expectedErrorMessage);
+        });
+
+        setTimeout(function () {
+            test.log("step 3: publish to a topic")
+            publisher.publish("com.myapp.topic", []);
+        }, 100);
+
+    }, function(error) {
+        testcase.ok(false, "Error occurred during the connection: " + error);
+        testcase.done();
+    });
+};
+
+// It should call the on_user_error handler, when an exception is thrown in the INVOCATION callback at the callee side,
+// when a remote procedure call is invoked. The wamp runtime error should be received on the caller side.
+exports.errorHandlingOnInvocation = function(testcase) {
+
+    // Prepare the test case
+
+    testcase.expect(3);
+    var timeout = testutil.create_timeout_handler(testcase);
+    var test = new testutil.Testlog("test/test_error_handling_on_invocation.txt");
+    var config = Object.assign({}, testutil.config);
+    var expectedErrorMessage = "Invocation handler user error.";
+    var expectedCustomMessage = "Exception raised in invocation handler:";
+
+    // Define the tested feature's on user error handler. The test case ends here.
+    config.on_user_error = function (error, customMessage) {
+
+        test.log("Step 7: The error handler is called");
+        testcase.deepEqual(error.message, expectedErrorMessage);
+        testcase.deepEqual(customMessage, expectedCustomMessage);
+    };
+
+    // Execute the test case
+
+    test.log("Step 1: Create two sessions.")
+    timeout.set();
+    autobahn.when.all(testutil.connect_n(2, config)).then(function(sessions) {
+        var callee = sessions[0];
+        var caller = sessions[1];
+
+        test.log("Step 2: Register an invocation handler in the callee role.")
+        callee.register("com.myapp.topic", function() {
+            test.log("Step 4: The invocation handler is called.")
+            test.log("Step 5: An is error occurred in the handler.")
+            throw Error(expectedErrorMessage);
+        });
+
+        setTimeout(function () {
+
+            test.log("Step 3: Call the topic in the caller role.");
+            caller.call("com.myapp.topic", []).then(function (result) {
+                testcase.ok(false, "The result of the call should not be successful.");
+            }, function (error) {
+                test.log("Step 8: The error is received on the callee side.")
+                test.log("Step 9: Finish the  test case.")
+                var check = test.check();
+                testcase.ok(!check, check);
+                timeout.clear();
+                testcase.done();
+            });
+        }, 100);
+
+    }, function(error) {
+        testcase.ok(false, "Error occurred during the connection:" + error);
+    });
+};

--- a/test/test_error_handling_on_colse.txt
+++ b/test/test_error_handling_on_colse.txt
@@ -1,0 +1,7 @@
+0 "Step 1: open a connection"
+1 "Step 2: the onopen handler is called."
+2 "Step 3: close the connection."
+3 "Step 4: the onclose handler is called"
+4 "Step 5: the handler has a user error"
+5 "Step 6: The error handler is called."
+6 "Step 7: finishing the test case."

--- a/test/test_error_handling_on_event.txt
+++ b/test/test_error_handling_on_event.txt
@@ -1,0 +1,7 @@
+0 "Step 1: make two connections"
+1 "Step 2: subscribe to a topic"
+2 "step 3: publish to a topic"
+3 "Step 4: the event handler is called"
+4 "Step 5: an error thrown in the event handler"
+5 "Step 6: the on user error is called"
+6 "Step 7: finishing the test cases"

--- a/test/test_error_handling_on_invocation.txt
+++ b/test/test_error_handling_on_invocation.txt
@@ -1,0 +1,8 @@
+0 "Step 1: Create two sessions."
+1 "Step 2: Register an invocation handler in the callee role."
+2 "Step 3: Call the topic in the caller role."
+3 "Step 4: The invocation handler is called."
+4 "Step 5: An is error occurred in the handler."
+5 "Step 7: The error handler is called"
+6 "Step 8: The error is received on the callee side."
+7 "Step 9: Finish the  test case."

--- a/test/test_error_handling_on_open.txt
+++ b/test/test_error_handling_on_open.txt
@@ -1,0 +1,5 @@
+0 "Step 1: open a connection."
+1 "Step 2: The onopen handler is called."
+2 "Step 3: A user error is occurred in the handler."
+3 "Step 4: The user error handler is called"
+4 "Step 5: Finish the test case"

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -28,6 +28,22 @@ var config = {
 }
 */
 
+var create_timeout_handler = function(testcase) {
+    var TIMEOUT = 3000;
+    var timer;
+    return {
+        set: function () {
+            timer = setTimeout(function() {
+                testcase.ok(false, 'Timeout!');
+                testcase.done();
+            }, TIMEOUT);
+        },
+        clear: function () {
+            clearTimeout(timer);
+        }
+    }
+}
+
 // shortcut config
 var default_config = {
    url: 'ws://127.0.0.1:8080/ws',
@@ -150,3 +166,4 @@ Testlog.prototype.check = function () {
 exports.Testlog = Testlog;
 exports.config = default_config;
 exports.connect_n = connect_n;
+exports.create_timeout_handler = create_timeout_handler;


### PR DESCRIPTION
Hi, here is my first attempt to #224. 

Finally, I chose the `on_user_error` and `on_internal_error` solution and did not make any custom error typing, simply pass through the error objects to the handler. I have created an error_handler utility function, which examines the error and the given error handler parameter, and if the error handler is a function, it is called, else a console.error is written --> so no hide away errors anymore.

I looked for a log references through session & connection and changed it to the function above, where it has a meaning. 

Added some end to end tests for onopen, onclose, oninvoke and on event cases. But not for the internal errors, neither for the onchallenge callback --> if you have some mocking tips I'm happy to create that part too.

The documentation is updated too. 