### PR TITLE
Replaced msgpack-lite with msgpack5

### DIFF
--- a/lib/autobahn.js
+++ b/lib/autobahn.js
@@ -19,7 +19,7 @@ var pjson = require('../package.json');
 var when = require('when');
 //var fn = require("when/function");
 
-var msgpack = require('msgpack-lite');
+var msgpack = require('msgpack5');
 var cbor = require('cbor');
 var nacl = require('tweetnacl');
 

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -78,9 +78,7 @@ MsgpackSerializer.prototype.serialize = function (obj) {
 
 MsgpackSerializer.prototype.unserialize = function (payload) {
    try {
-      // need to encapsulate ArrayBuffer into Uint8Array for msgpack decoding
-      // https://github.com/kawanet/msgpack-lite/issues/44
-      var obj = msgpack.decode(new Uint8Array(payload));
+      var obj = msgpack.decode(payload);
       return obj;
    } catch (e) {
       log.warn('MessagePack decoding error', e);

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -56,25 +56,19 @@ JSONSerializer.prototype.unserialize = function (payload) {
 exports.JSONSerializer = JSONSerializer;
 
 
-// https://github.com/kawanet/msgpack-lite/
-// https://github.com/kawanet/int64-buffer
-var msgpack = require('msgpack-lite');
-
-// this is needed for correct msgpack serialization of WAMP session IDs
-var Uint64BE = require('int64-buffer').Uint64BE;
+// https://github.com/mcollina/msgpack5
+var msgpack = require('msgpack5')({forceFloat64: true});
 
 function MsgpackSerializer() {
    this.SERIALIZER_ID = 'msgpack';
    this.BINARY = true;
-   this.codec = msgpack.createCodec();
 
-   // msgpack: Uint64BE ensures that ID is encoded as int instead of double
-   this.newid = function () { return new Uint64BE(newid()); };
+   this.newid = newid;
 }
 
 MsgpackSerializer.prototype.serialize = function (obj) {
    try {
-      var payload = msgpack.encode(obj, {codec: this.codec});
+      var payload = msgpack.encode(obj);
       return payload;
    } catch (e) {
       log.warn('MessagePack encoding error', e);
@@ -86,7 +80,7 @@ MsgpackSerializer.prototype.unserialize = function (payload) {
    try {
       // need to encapsulate ArrayBuffer into Uint8Array for msgpack decoding
       // https://github.com/kawanet/msgpack-lite/issues/44
-      var obj = msgpack.decode(new Uint8Array(payload), {codec: this.codec});
+      var obj = msgpack.decode(new Uint8Array(payload));
       return obj;
    } catch (e) {
       log.warn('MessagePack decoding error', e);

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "crypto-js": ">= 3.1.8",
-    "int64-buffer": ">= 0.1.9",
-    "msgpack-lite": ">= 0.1.26",
+    "msgpack5": ">= 3.6.0",
     "cbor": ">= 3.0.0",
     "tweetnacl": ">= 0.14.3",
     "when": ">= 3.7.7",


### PR DESCRIPTION
This fixes subscription IDs being sent to the router as floats due to msgpack-lite's buggy handling of large numbers.