### PR TITLE
Removed broken msgpack ext type support

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -86,26 +86,6 @@ MsgpackSerializer.prototype.unserialize = function (payload) {
    }
 };
 
-/**
- * Register a packer and/or unpacker functions for a given type.
- *
- * The msgpack specification allows applications to register up to 128 extension
- * types.
- *
- * @param code numeric extension code (between 0-127)
- * @param type constructor for the given type (only required when packer is defined)
- * @param packer a function that takes an object and returns a Buffer
- * @param unpacker a function that takes a Buffer and returns an instance of the given type
- */
-MsgpackSerializer.prototype.registerExtType = function (code, type, packer, unpacker) {
-   if (packer && type) {
-      this.codec.addExtPacker(code, type, packer);
-   }
-   if (unpacker) {
-      this.codec.addExtUnpacker(code, unpacker);
-   }
-};
-
 exports.MsgpackSerializer = MsgpackSerializer;
 
 


### PR DESCRIPTION
This feature violated WAMP's design goals. Use of ext types should be restricted to scenarios where payload transparency is used. But more importantly, the code was broken by the move to msgpack5.