### PR TITLE
Patch for Issue #358

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -929,7 +929,16 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
 
                when_fn.call(self._onchallenge, self, method, extra).then(
                   function (signature) {
-                     var msg = [MSG_TYPE.AUTHENTICATE, signature, {}];
+
+                     if(typeof signature === "string"){
+                        var msg = [MSG_TYPE.AUTHENTICATE, signature, {}];
+                     } else if (typeof signature === "object") {
+                        var signatureString = signature[0];
+                        var authExtra = signature[1];
+
+                        var msg = [MSG_TYPE.AUTHENTICATE, signatureString, authExtra];
+                     }
+
                      self._send_wamp(msg);
                   },
                   function (err) {


### PR DESCRIPTION
I just patched my issue #358 by myself. 

I am not sure, how to check for an array correctly in an non-ES6 environment. I just did `typeof m === "object"`, which should be enough in this specific case.

