### PR TITLE
Introduced TLS Support

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -216,6 +216,12 @@ Options that define **Custom error handlers:**
     - when a protocol violation is occured,
     - when no `onchallenge` defined, but a challenge request is received due to authenticate the client,
 
+Options that control **tls connection**:
+-   `tlsConfiguration`: *object*
+    - `ca`: *Loaded CA file*
+    - `cert`: *Loaded certificate file*
+    - `key`: *Loaded key file*
+
 ```javascript
     var connection = new autobahn.Connection({
        on_user_error: function (error, customErrorMessage) {

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -216,11 +216,6 @@ Options that define **Custom error handlers:**
     - when a protocol violation is occured,
     - when no `onchallenge` defined, but a challenge request is received due to authenticate the client,
 
-Options that control **tls connection**:
--   `tlsConfiguration`: *object*
-    - `ca`: *Loaded CA file*
-    - `cert`: *Loaded certificate file*
-    - `key`: *Loaded key file*
 
 ```javascript
     var connection = new autobahn.Connection({
@@ -246,7 +241,13 @@ Options that control **tls connection**:
 > In a case of error handling in the Callee role, when the invocation handler is executed, the error
 > is reported on the Callee side (with the custom error handler or an error log), but despite that the
 > error is sent back to the Dealer, and the Caller will receive a `runtime.error` wamp message.
-  
+
+
+ Options that control **tls connection**:
+ -   `tlsConfiguration`: *object*
+     - `ca`: *Buffer | String* - CA
+     - `cert`: *Buffer | String* - Certificate Public Key
+     - `key`: *Buffer | String* - Certificate Private Key
   
 Connection Properties
 ---------------------

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -73,7 +73,8 @@ var Connection = function (options) {
       self._options.transports = [
          {
             type: 'websocket',
-            url: self._options.url
+            url: self._options.url,
+            tlsConfiguration: self._options.tlsConfiguration
          }
       ];
    }

--- a/lib/transport/websocket.js
+++ b/lib/transport/websocket.js
@@ -97,7 +97,17 @@ Factory.prototype.create = function () {
                protocols = protocols.join(',');
             }
             options.protocol = protocols;
-         } 
+         }
+
+         if (self._options.url.startsWith('wss://')) {
+            // Using TLS
+            // Only using the known working flags in the options.
+            // https://nodejs.org/api/https.html#https_https_request_options_callback
+            options.ca = self._options.tlsConfiguration.ca;
+            options.cert = self._options.tlsConfiguration.cert;
+            options.key = self._options.tlsConfiguration.key;
+            options.rejectUnauthorized = false;
+         }
          
          websocket = new WebSocket(self._options.url, protocols, options);
 


### PR DESCRIPTION
I just added support for TLS on websockets, which is used for [TLS Client Authentication](https://crossbar.io/docs/TLS-Client-Certificate-Authentication/).

