### PR TITLE
Add binary serialization for msgpack

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -57,8 +57,16 @@ exports.JSONSerializer = JSONSerializer;
 
 
 try {
+  function encodeArrayBuffer(buf) {
+    return buf;
+  }
+
+  function decodeArrayBuffer(buf) {
+    return buf.buffer;
+  }
    // https://github.com/mcollina/msgpack5
    var msgpack = require('msgpack5')({forceFloat64: true});
+   msgpack.register(42, ArrayBuffer, encodeArrayBuffer, decodeArrayBuffer);
 
    function MsgpackSerializer() {
       this.SERIALIZER_ID = 'msgpack';


### PR DESCRIPTION
This PR adds a custom msgpack type which is decoded as Uint8Array/ArrayBuffer and makes it possible to stream binary data right into the browser.

Linked PR with more background: https://github.com/gammazero/nexus/pull/121

I'll also create an addition to the WAMP spec to handle binary data properly.