### PR TITLE
Missing 'self' in some functions

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -139,6 +139,9 @@ var Connection = function (options) {
 
 
 Connection.prototype._create_transport = function () {
+   
+   var self = this;
+   
    for (var i = 0; i < this._transport_factories.length; ++i) {
       var transport_factory = this._transport_factories[i];
       log.debug("trying to create WAMP transport of type: " + transport_factory.type);
@@ -162,6 +165,9 @@ Connection.prototype._create_transport = function () {
 Connection.prototype._init_transport_factories = function () {
     // WAMP transport
     //
+    
+    var self = this;
+   
     var transports, transport_options, transport_factory, transport_factory_klass;
 
     util.assert(this._options.transports, "No transport.factory specified");


### PR DESCRIPTION
var self = this; was not defined, so it raised error: TypeError: Cannot read property 'on_internal_error' of undefined