### PR TITLE
quickfix websocket close code #141

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -281,7 +281,7 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
 
 
    self._protocol_violation = function (reason) {
-      self._socket.close(1002, "protocol violation: " + reason);
+      self._socket.close(3002, "protocol violation: " + reason);
       util.handle_error(self._on_internal_error, Error("failing transport due to protocol violation: " + reason))
    };
 
@@ -945,7 +945,7 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
                       util.handle_error(self._on_user_error, err, "onchallenge() raised: ");
                       var msg = [MSG_TYPE.ABORT, {message: "sorry, I cannot authenticate (onchallenge handler raised an exception)"}, "wamp.error.cannot_authenticate"];
                       self._send_wamp(msg);
-                      self._socket.close(1000);
+                      self._socket.close(3000);
                   }
                );
             } else {
@@ -953,7 +953,7 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
 
                var msg = [MSG_TYPE.ABORT, {message: "sorry, I cannot authenticate (no onchallenge handler set)"}, "wamp.error.cannot_authenticate"];
                self._send_wamp(msg);
-               self._socket.close(1000);
+               self._socket.close(3000);
             }
 
          } else {


### PR DESCRIPTION
I think this quick solution is still better than the status quo.
It prevents the javascript error and you can inspect the actual protocol violation in the app code that needs fixing.