### PR TITLE
Fix session scope ID counter wrapping.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -289,9 +289,10 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
    self._MESSAGE_MAP[MSG_TYPE.ERROR] = {};
 
    var next_req_id = 0;
-   self._new_request_id = function(){
-      next_req_id += 1;
-      if (next_req_id > 9007199254740992) {
+   self._new_request_id = function() {
+      if (next_req_id < 9007199254740992) {
+         next_req_id += 1;
+      } else {
          next_req_id = 1;
       }
       return next_req_id;


### PR DESCRIPTION
I had used the counter wrapping method from Autobahn|Python, where one can use integers with wild abandon, but it was not JavaScript safe. This fixes the behavior in V8 and SpiderMonkey where the IDs generated were all 9007199254740992 once that ID had been reached.

Follow up to crossbario/autobahn-js#377.