### PR TITLE
change browser entry for rawsocket.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "browser": {
     "ws": false,
-    "lib/transport/rawsocket.js": false,
+    "./lib/transport/rawsocket.js": false,
     "cbor": false,
     "randombytes": false
   },


### PR DESCRIPTION
If you use autobahn-js with rollup and rollup-plugin-node-resolve cannot
resolve the path to "lib/transport/rawsocket.js". This leads to the error
that "net" cannot be imported (which is correct, it is not available
because it is a core node module).

rollup-plugin-node-resolve uses the `Node Resolution Algorithm` to resolve
packages (https://nodejs.org/api/modules.html#modules_all_together).
This means that the path of the file should either start with './' or
'/' to be found.