### PR TITLE
Introduce hello custom details as optional connection option

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -260,12 +260,12 @@ Options that define **Custom error handlers:**
      - `cert`: *Buffer | String* - Certificate Public Key
      - `key`: *Buffer | String* - Certificate Private Key
 
-Options that provides additional opening information:
- -    `helloDetails`: *object*
+Options that provide additional opening information:
+ -    `hello_custom_details`: *object*
 
  > **note**
  >
- > `helloDetails` object will be passed into the initial message sent by client after transport is established.
+ > `hello_custom_details` object contains custom attributes that will be passed into the initial message sent by client after transport is established.
 
 Connection Properties
 ---------------------

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -217,10 +217,10 @@ Options that control **WebSocket heartbeat on NodeJS**:
 
 
 Options that define **Custom error handlers:**
--   `on_user_error`: *function* - This error handler is called in the following cases: 
+-   `on_user_error`: *function* - This error handler is called in the following cases:
     - an exception raised in `onopen`, `onclose`, `onchallenge` callbacks,
     - an exception raised in the event handler in the subscriber role,
-    - an error occurred in the invocation handler in the callee role (the handler called in the client, before 
+    - an error occurred in the invocation handler in the callee role (the handler called in the client, before
       the error message is sent back to the Dealer.)
 -   `on_internal_error`: *function* - This error handler is called in the following cases:
     - not able to create a Wamp transport,
@@ -231,11 +231,11 @@ Options that define **Custom error handlers:**
 ```javascript
     var connection = new autobahn.Connection({
        on_user_error: function (error, customErrorMessage) {
-           // here comes your custom error handling, when a 
+           // here comes your custom error handling, when a
            // something went wrong in a user defined callback.
         },
         on_internal_error: function (error, customErrorMessage) {
-           // here comes your custom error handling, when a 
+           // here comes your custom error handling, when a
            // something went wrong in the autobahn core.
         }
         // ... other options
@@ -245,7 +245,7 @@ Options that define **Custom error handlers:**
 
 > **note**
 >
-> If no error handler is defined for these functions, an error level consol log will be written. 
+> If no error handler is defined for these functions, an error level consol log will be written.
 
 > **note**
 >
@@ -259,7 +259,14 @@ Options that define **Custom error handlers:**
      - `ca`: *Buffer | String* - CA
      - `cert`: *Buffer | String* - Certificate Public Key
      - `key`: *Buffer | String* - Certificate Private Key
-  
+
+Options that provides additional opening information:
+ -    `helloDetails`: *object*
+
+ > **note**
+ >
+ > `helloDetails` object will be passed into the initial message sent by client after transport is established.
+
 Connection Properties
 ---------------------
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -305,7 +305,7 @@ Connection.prototype.open = function () {
       }
 
       // create a new WAMP session using the WebSocket connection as transport
-      self._session = new session.Session(self._transport, self._defer, self._options.onchallenge, self._options.on_user_error, self._options.on_internal_error, self._options.helloDetails);
+      self._session = new session.Session(self._transport, self._defer, self._options.onchallenge, self._options.on_user_error, self._options.on_internal_error, self._options.hello_custom_details);
       self._session_close_reason = null;
       self._session_close_message = null;
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -139,9 +139,9 @@ var Connection = function (options) {
 
 
 Connection.prototype._create_transport = function () {
-   
+
    var self = this;
-   
+
    for (var i = 0; i < this._transport_factories.length; ++i) {
       var transport_factory = this._transport_factories[i];
       log.debug("trying to create WAMP transport of type: " + transport_factory.type);
@@ -165,9 +165,9 @@ Connection.prototype._create_transport = function () {
 Connection.prototype._init_transport_factories = function () {
     // WAMP transport
     //
-    
+
     var self = this;
-   
+
     var transports, transport_options, transport_factory, transport_factory_klass;
 
     util.assert(this._options.transports, "No transport.factory specified");
@@ -305,7 +305,7 @@ Connection.prototype.open = function () {
       }
 
       // create a new WAMP session using the WebSocket connection as transport
-      self._session = new session.Session(self._transport, self._defer, self._options.onchallenge, self._options.on_user_error, self._options.on_internal_error);
+      self._session = new session.Session(self._transport, self._defer, self._options.onchallenge, self._options.on_user_error, self._options.on_internal_error, self._options.helloDetails);
       self._session_close_reason = null;
       self._session_close_message = null;
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -218,7 +218,7 @@ var MSG_TYPE = {
 
 
 
-var Session = function (socket, defer, onchallenge, on_user_error, on_internal_error, hello_details) {
+var Session = function (socket, defer, onchallenge, on_user_error, on_internal_error, hello_custom_details) {
 
    var self = this;
 
@@ -236,7 +236,7 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
    self._on_internal_error = on_internal_error;
 
    // additional opeining information
-   self._hello_details = hello_details;
+   self._hello_custom_details = hello_custom_details;
 
 
    // the WAMP session ID
@@ -1166,7 +1166,7 @@ Session.prototype.join = function (realm, authmethods, authid, authextra) {
    self._goodbye_sent = false;
    self._realm = realm;
 
-   var details = self._hello_details || {};
+   var details = self._hello_custom_details || {};
    details.roles = WAMP_FEATURES;
 
    if (details.authmethods === undefined && authmethods) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -218,7 +218,7 @@ var MSG_TYPE = {
 
 
 
-var Session = function (socket, defer, onchallenge, on_user_error, on_internal_error) {
+var Session = function (socket, defer, onchallenge, on_user_error, on_internal_error, hello_details) {
 
    var self = this;
 
@@ -234,6 +234,9 @@ var Session = function (socket, defer, onchallenge, on_user_error, on_internal_e
    // custom error handlers
    self._on_user_error = on_user_error;
    self._on_internal_error = on_internal_error;
+
+   // additional opeining information
+   self._hello_details = hello_details;
 
 
    // the WAMP session ID
@@ -1163,16 +1166,16 @@ Session.prototype.join = function (realm, authmethods, authid, authextra) {
    self._goodbye_sent = false;
    self._realm = realm;
 
-   var details = {};
+   var details = self._hello_details || {};
    details.roles = WAMP_FEATURES;
 
-   if (authmethods) {
+   if (details.authmethods === undefined && authmethods) {
       details.authmethods = authmethods;
    }
-   if (authid) {
+   if (details.authid === undefined && authid) {
       details.authid = authid;
    }
-   if (authextra) {
+   if (details.authextra === undefined && authextra) {
       details.authextra = authextra;
    }
 


### PR DESCRIPTION
Hello message is the initial message sent by client when transport is established, currently the hello message details is only configurable with a few keys:
- authmethods
- authid
- authextra

It's useful to accept custom attributes for hello message details, a common use case is router needs to store and maintain information of each client, in order to make use of it later as caller/callee. 

Other libraries that also accept custom hello message details:
- [wampy.js](https://github.com/KSDaemon/wampy.js/blob/dev/src/wampy.js#L549)
- [nexus](https://github.com/gammazero/nexus/blob/master/client/client.go#L43)

I picked the option name as `hello_custom_details`, and it's an object that will be merged with the details object for hello message, not sure if the existing options such as `authmethods` should be overridable or not?