### PR TITLE
Check if the system runs inside nwjs.io

### DIFF
--- a/lib/transport/websocket.js
+++ b/lib/transport/websocket.js
@@ -100,7 +100,7 @@ Factory.prototype.create = function () {
    // running in Node.js
    //
    if (global.process && global.process.versions.node
-       && !global.process.versions.hasOwnProperty('electron')) {
+       && !global.process.versions.hasOwnProperty('electron') && !global.process.__nwjs) {
 
       (function () {
 


### PR DESCRIPTION
Socket creation was not working while using nwjs.io so added one more check if the system runs inside nwjs.