### PR TITLE
Use new eth accounts constructor

### DIFF
--- a/lib/xbr/buyer.js
+++ b/lib/xbr/buyer.js
@@ -14,7 +14,7 @@ var SimpleBuyer = function (buyerKey, maxPrice) {
     this._maxPrice = maxPrice;
     this._deferred_factory = util.deferred_factory();
 
-    var account = new eth_accounts.Accounts().privateKeyToAccount(buyerKey);
+    var account = new eth_accounts().privateKeyToAccount(buyerKey);
     this._addr = eth_util.toBuffer(account.address);
 
     this._keyPair = nacl.box.keyPair();

--- a/lib/xbr/seller.js
+++ b/lib/xbr/seller.js
@@ -15,7 +15,7 @@ var Seller = function (sellerKey) {
     this.sessionRegs = [];
     this._deferred_factory = util.deferred_factory();
 
-    var account = new eth_accounts.Accounts().privateKeyToAccount(sellerKey);
+    var account = new eth_accounts().privateKeyToAccount(sellerKey);
     this._addr = eth_util.toBuffer(account.address);
     this._privateKey = eth_util.toBuffer(account.privateKey);
 };


### PR DESCRIPTION
There was an update to the way eth accounts package exports its symbols, making our xbr code to not work anymore, this should fix that.

The relevant upstream change was https://github.com/ethereum/web3.js/commit/44d904d2364bae77886cb5a638a3c0f1401298e1#diff-7bb2a20126193b9ecfe4723f83429c49