### PR TITLE
Remove useless xbr dependencies for normal autobahn builds and improve scons env autodetection.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,8 @@
 import os
 import json
 import pkg_resources
+import subprocess
+from sys import platform
 
 taschenmesser = pkg_resources.resource_filename('taschenmesser', '..')
 #taschenmesser = "../../infrequent/taschenmesser"
@@ -8,12 +10,18 @@ ENV=os.environ
 
 if 'JAVA_HOME' in ENV:
     print('Using from environment: JAVA_HOME={}'.format(ENV['JAVA_HOME']))
+elif platform == "darwin":
+    ENV['JAVA_HOME'] = subprocess.check_output("/usr/libexec/java_home").strip()
+    print('Using OSX default: JAVA_HOME={}'.format(ENV['JAVA_HOME']))
+elif platform == "linux" or platform == "linux2":
+    ENV['JAVA_HOME'] = subprocess.check_output("echo 'System.out.println(java.lang.System.getProperty(\"java.home\"));' | jshell  -", shell=True).strip()
+    print('Using Linux default: JAVA_HOME={}'.format(ENV['JAVA_HOME']))
 
 if 'JS_COMPILER' in ENV:
     print('Using from environment: JS_COMPILER={}'.format(ENV['JS_COMPILER']))
 else:
     #ENV['JS_COMPILER'] = '/usr/local/lib/node_modules/google-closure-compiler-java/compiler.jar'
-    ENV['JS_COMPILER'] = '/work/node_modules/google-closure-compiler-java/compiler.jar'
+    ENV['JS_COMPILER'] = str(Dir('.').abspath) + '/node_modules/google-closure-compiler-java/compiler.jar'
     print('Using builtin: JS_COMPILER={}'.format(ENV['JS_COMPILER']))
 
 env = Environment(tools = ['default', 'taschenmesser'],

--- a/index-xbr.js
+++ b/index-xbr.js
@@ -1,0 +1,14 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//  AutobahnJS - http://autobahn.ws, http://wamp.ws
+//
+//  A JavaScript library for WAMP ("The Web Application Messaging Protocol").
+//
+//  Copyright (c) Crossbar.io Technologies GmbH and contributors
+//
+//  Licensed under the MIT License.
+//  http://www.opensource.org/licenses/mit-license.php
+//
+///////////////////////////////////////////////////////////////////////////////
+
+module.exports = require('./lib/xbr.js');

--- a/lib/xbr.js
+++ b/lib/xbr.js
@@ -42,6 +42,7 @@ var serializer = require('./serializer.js');
 var persona = require('./auth/persona.js');
 var cra = require('./auth/cra.js');
 var cryptosign = require('./auth/cryptosign.js');
+var xbr = require('./xbr/xbr.js');
 
 exports.version = pjson.version;
 
@@ -71,3 +72,4 @@ exports.nacl = nacl;
 
 exports.util = util;
 exports.log = log;
+exports.xbr = xbr;

--- a/package-xbr.json
+++ b/package-xbr.json
@@ -36,7 +36,7 @@
     "web3": "^1.0.0-beta.50"
   },
   "devDependencies": {},
-  "main": "index.js",
+  "main": "index-xbr.js",
   "scripts": {
     "test": "truffle test --network ganache",
     "coverage": "solidity-coverage"

--- a/package.json
+++ b/package.json
@@ -15,12 +15,8 @@
     "msgpack5": ">= 3.6.0",
     "tweetnacl": ">= 0.14.3",
     "tweetnacl-sealedbox-js": ">=1.1.0",
-    "web3": ">=1.0.0-beta.53",
     "when": ">= 3.7.7",
-    "ws": ">= 1.1.4",
-    "sha3": ">=2.0.1",
-    "truffle-contract": ">=4.0.10",
-    "uuid": ">=3.3.2"
+    "ws": ">= 1.1.4"
   },
   "optionalDependencies": {
     "bufferutil": ">= 1.2.1",
@@ -47,9 +43,6 @@
     "WebSocket",
     "RPC",
     "PubSub",
-    "ethereum",
-    "solidity",
-    "xbr",
     "crossbar",
     "autobahn",
     "wamp",


### PR DESCRIPTION
Not sure why xbr is even in the same repository as autobahn(shouldn't it just import autobahn and be a separate project?) but this should fix normal autobahn builds so that they don't pull in a bunch of useless eth dependencies.

I also added some fallback autodetection for `JAVA_HOME` and `JS_COMPILER` which should work on most systems.