### PR TITLE
Remove redundant fs import

### DIFF
--- a/packages/autobahn/lib/util.js
+++ b/packages/autobahn/lib/util.js
@@ -445,7 +445,6 @@ let sleep = async function sleep (ms) {
 };
 
 let _read_file = async function read_file (path) {
-   let fs = require("fs");
    return new Promise((resolve, reject) => {
       fs.readFile(path, function (err, data) {
          if (err) {


### PR DESCRIPTION
Should probably fix https://github.com/crossbario/autobahn-js/issues/514

We only expose `read_file` when `fs` is in globals. Hence no need to explicitly import fs.