### PR TITLE
bump version

### DIFF
--- a/packages/autobahn-xbr/package.json
+++ b/packages/autobahn-xbr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobahn-xbr",
-  "version": "20.9.1",
+  "version": "20.9.2",
   "description": "The XBR Protocol (smart contracts package)",
   "main": "index.js",
   "files": [

--- a/packages/autobahn/package.json
+++ b/packages/autobahn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobahn",
-  "version": "20.9.1",
+  "version": "20.9.2",
   "description": "An implementation of The Web Application Messaging Protocol (WAMP).",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
The previous build shipped XBR contracts in the wrong directory. Issue was fixed via https://github.com/crossbario/autobahn-js/pull/533