### PR TITLE
Warning spamming in Transport.onclose

### DIFF
--- a/packages/autobahn/lib/connection.js
+++ b/packages/autobahn/lib/connection.js
@@ -338,7 +338,7 @@ Connection.prototype.open = function () {
             will_retry: next_retry.will_retry
          };
 
-         log.warn("connection closed", reason, details);
+         log.debug("connection closed", reason, details);
 
          // fire app code handler
          //
@@ -375,7 +375,7 @@ Connection.prototype.open = function () {
                log.warn("giving up trying to auto-reconnect!");
             }
          } else {
-            log.warn("auto-reconnect disabled!", self._retry, stop_retrying);
+            log.debug("auto-reconnect disabled!", self._retry, stop_retrying);
          }
       }
    }


### PR DESCRIPTION
Do not warn by default, only for reconnection cases

Closes #538