### PR TITLE
fix example code in "registering procedures" of "programming" doc

### DIFF
--- a/doc/programming.md
+++ b/doc/programming.md
@@ -103,7 +103,7 @@ Registering Procedures
 To make a procedure available for remote calling, the procedure needs to be *registered*. Registering a procedure is done by calling the `register` method on the `session` object:
 
 ``` js
-connection.onopen(session, details) {
+connection.onopen = function (session) {
    var add2 = function(args) {
       return args[0] + args[1];
    };


### PR DESCRIPTION
As far as I can tell, the existing version there was not syntactically valid javascript.