### PR TITLE
Allow for no retry jitter

### DIFF
--- a/packages/autobahn/lib/connection.js
+++ b/packages/autobahn/lib/connection.js
@@ -75,7 +75,7 @@ var Connection = function (options) {
 
    // the SD of a Gaussian to jitter the delay on each retry cycle
    // as a fraction of the mean
-   self._retry_delay_jitter = self._options.retry_delay_jitter || 0.1;
+   self._retry_delay_jitter = self._options.retry_delay_jitter !== 'undefined' ? self._options.retry_delay_jitter : 0.1;
 
    // reconnection tracking
    //


### PR DESCRIPTION
There needs to be a way to eliminate retry jitter. For my use case, I need the autobahn client to attempt to reconnect to a server every 2 seconds. With the pseudo-random retry times introduced by the jitter, my retry time can end up anywhere from a few milliseconds to 30 seconds (depending on how long I leave it). That's not ideal for me.

The code already has a clause that only applies retry jitter if the `_retry_delay_jitter` property is truthy. So if the property were 0, then no retry jitter would be applied.

However, due to the way `self._retry_delay_jitter` is initialized, it will never accept a value of 0. This pull request changes that and allows `self._retry_delay_jitter` to be set to 0.