### PR TITLE
fix: put upper limit to dependency module versions

### DIFF
--- a/packages/autobahn/package.json
+++ b/packages/autobahn/package.json
@@ -14,11 +14,11 @@
     "node": ">= 7.10.1"
   },
   "dependencies": {
-    "cbor": ">= 3.0.0",
-    "crypto-js": ">=3.1.8",
-    "msgpack5": ">= 3.6.0",
-    "tweetnacl": ">= 0.14.3",
-    "ws": ">= 1.1.4"
+    "cbor": ">=3.0.0 <8.0.0",
+    "crypto-js": ">=3.1.8 <5.0.0",
+    "msgpack5": ">= 3.6.0 <6.0.0",
+    "tweetnacl": ">=0.14.3 <2.0.0",
+    "ws": ">=1.1.4 <8.0.0"
   },
   "optionalDependencies": {
     "bufferutil": ">= 1.2.1",


### PR DESCRIPTION
put upper limit to dependency module versions so that a major release don't break autobahn