### PR TITLE
Bump version to 22.11.1

### DIFF
--- a/packages/autobahn-xbr/package.json
+++ b/packages/autobahn-xbr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobahn-xbr",
-  "version": "22.10.1",
+  "version": "22.11.1",
   "description": "The XBR Protocol (smart contracts package)",
   "main": "index.js",
   "files": [

--- a/packages/autobahn/package.json
+++ b/packages/autobahn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobahn",
-  "version": "22.10.1",
+  "version": "22.11.1",
   "description": "An implementation of The Web Application Messaging Protocol (WAMP).",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
hotfix to include the CBOR serializer fix when payload size is larger than 16kb