### PR TITLE
Fix link to autobahn project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ WAMP for Browsers and NodeJS.
 
 ---
 
-**Autobahn**|JS is a subproject of the [Autobahn project](http://autobahn.ws/) and provides an open-source implementation of the **[Web Application Messaging Protocol V2](http://wamp.ws/)** in JavaScript under the [MIT license](/LICENSE).
+**Autobahn**|JS is a subproject of the [Autobahn project](https://autobahn.readthedocs.io) and provides an open-source implementation of the **[Web Application Messaging Protocol V2](http://wamp.ws/)** in JavaScript under the [MIT license](/LICENSE).
 
 WAMP provides asynchronous **Remote Procedure Calls** and **Publish & Subscribe** for applications in *one* protocol running over [WebSocket](http://tools.ietf.org/html/rfc6455) (and fallback transports for old browsers).
 


### PR DESCRIPTION
The current link to autobahn.ws leads to a porn website. I don't think this is intended. I googled the project and found a readthedocs page, which is probably more suitable